### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -85,7 +85,7 @@ func runLogger(ctx context.Context, logger *zap.Logger) {
 	functionLogger.Start(ctx, logger)
 }
 
-func getPort(logger *zap.Logger, portArg interface{}) int {
+func getPort(logger *zap.Logger, portArg any) int {
 	portArgStr := portArg.(string)
 	port, err := strconv.Atoi(portArgStr)
 	if err != nil {
@@ -94,7 +94,7 @@ func getPort(logger *zap.Logger, portArg interface{}) int {
 	return port
 }
 
-func getStringArgWithDefault(arg interface{}, defaultValue string) string {
+func getStringArgWithDefault(arg any, defaultValue string) string {
 	if arg != nil {
 		return arg.(string)
 	} else {
@@ -102,7 +102,7 @@ func getStringArgWithDefault(arg interface{}, defaultValue string) string {
 	}
 }
 
-func getServiceName(arguments map[string]interface{}) string {
+func getServiceName(arguments map[string]any) string {
 	serviceName := "Fission-Unknown"
 
 	if arguments["--controllerPort"] != nil {

--- a/cmd/preupgradechecks/main.go
+++ b/cmd/preupgradechecks/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fission/fission/pkg/utils/signals"
 )
 
-func getStringArgWithDefault(arg interface{}, defaultValue string) string {
+func getStringArgWithDefault(arg any, defaultValue string) string {
 	if arg != nil {
 		return arg.(string)
 	} else {

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -104,7 +104,7 @@ func AggregateValidationErrors(objName string, err error) error {
 	return result.ErrorOrNil()
 }
 
-func MakeValidationErr(errType ValidationErrorType, field string, val interface{}, detail ...string) ValidationError {
+func MakeValidationErr(errType ValidationErrorType, field string, val any, detail ...string) ValidationError {
 	return ValidationError{
 		Type:     errType,
 		Field:    field,

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -301,11 +301,11 @@ func (pkgw *packageWatcher) packageInformerHandler() k8sCache.ResourceEventHandl
 		}
 	}
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			pkg := obj.(*fv1.Package)
 			processPkg(pkg)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldPkg := oldObj.(*fv1.Package)
 			pkg := newObj.(*fv1.Package)
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -37,10 +37,10 @@ type (
 	Value struct {
 		ctime time.Time
 		atime time.Time
-		value interface{}
+		value any
 	}
 	Cache struct {
-		cache          map[interface{}]*Value
+		cache          map[any]*Value
 		ctimeExpiry    time.Duration
 		atimeExpiry    time.Duration
 		requestChannel chan *request
@@ -48,15 +48,15 @@ type (
 
 	request struct {
 		requestType
-		key             interface{}
-		value           interface{}
+		key             any
+		value           any
 		responseChannel chan *response
 	}
 	response struct {
 		error
-		existingValue interface{}
-		mapCopy       map[interface{}]interface{}
-		value         interface{}
+		existingValue any
+		mapCopy       map[any]any
+		value         any
 	}
 )
 
@@ -74,7 +74,7 @@ func (c *Cache) IsOld(v *Value) bool {
 
 func MakeCache(ctimeExpiry, atimeExpiry time.Duration) *Cache {
 	c := &Cache{
-		cache:          make(map[interface{}]*Value),
+		cache:          make(map[any]*Value),
 		ctimeExpiry:    ctimeExpiry,
 		atimeExpiry:    atimeExpiry,
 		requestChannel: make(chan *request),
@@ -133,7 +133,7 @@ func (c *Cache) service() {
 			}
 			// no response
 		case COPY:
-			resp.mapCopy = make(map[interface{}]interface{})
+			resp.mapCopy = make(map[any]any)
 			for k, v := range c.cache {
 				resp.mapCopy[k] = v.value
 			}
@@ -146,7 +146,7 @@ func (c *Cache) service() {
 	}
 }
 
-func (c *Cache) Get(key interface{}) (interface{}, error) {
+func (c *Cache) Get(key any) (any, error) {
 	respChannel := make(chan *response)
 	c.requestChannel <- &request{
 		requestType:     GET,
@@ -159,7 +159,7 @@ func (c *Cache) Get(key interface{}) (interface{}, error) {
 
 // if key exists in the cache, the new value is NOT set; instead an
 // error and the old value are returned
-func (c *Cache) Set(key interface{}, value interface{}) (interface{}, error) {
+func (c *Cache) Set(key any, value any) (any, error) {
 	respChannel := make(chan *response)
 	c.requestChannel <- &request{
 		requestType:     SET,
@@ -171,7 +171,7 @@ func (c *Cache) Set(key interface{}, value interface{}) (interface{}, error) {
 	return resp.existingValue, resp.error
 }
 
-func (c *Cache) Delete(key interface{}) error {
+func (c *Cache) Delete(key any) error {
 	respChannel := make(chan *response)
 	c.requestChannel <- &request{
 		requestType:     DELETE,
@@ -182,7 +182,7 @@ func (c *Cache) Delete(key interface{}) error {
 	return resp.error
 }
 
-func (c *Cache) Copy() map[interface{}]interface{} {
+func (c *Cache) Copy() map[any]any {
 	respChannel := make(chan *response)
 	c.requestChannel <- &request{
 		requestType:     COPY,

--- a/pkg/canaryconfigmgr/canaryConfigMgr.go
+++ b/pkg/canaryconfigmgr/canaryConfigMgr.go
@@ -102,17 +102,17 @@ func MakeCanaryConfigMgr(logger *zap.Logger, fissionClient versioned.Interface, 
 
 func (canaryCfgMgr *canaryConfigMgr) CanaryConfigEventHandlers() {
 	(*canaryCfgMgr.canaryConfigInformer).AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			canaryConfig := obj.(*fv1.CanaryConfig)
 			if canaryConfig.Status.Status == fv1.CanaryConfigStatusPending {
 				go canaryCfgMgr.addCanaryConfig(canaryConfig)
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			canaryConfig := obj.(*fv1.CanaryConfig)
 			go canaryCfgMgr.deleteCanaryConfig(canaryConfig)
 		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		UpdateFunc: func(oldObj any, newObj any) {
 			oldConfig := oldObj.(*fv1.CanaryConfig)
 			newConfig := newObj.(*fv1.CanaryConfig)
 			if oldConfig.ObjectMeta.ResourceVersion != newConfig.ObjectMeta.ResourceVersion &&

--- a/pkg/executor/cms/cmhandler.go
+++ b/pkg/executor/cms/cmhandler.go
@@ -51,9 +51,9 @@ func ConfigMapEventHandlers(ctx context.Context, logger *zap.Logger, fissionClie
 	kubernetesClient kubernetes.Interface, types map[fv1.ExecutorType]executortype.ExecutorType) k8sCache.ResourceEventHandlerFuncs {
 
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) {},
-		DeleteFunc: func(obj interface{}) {},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		AddFunc:    func(obj any) {},
+		DeleteFunc: func(obj any) {},
+		UpdateFunc: func(oldObj any, newObj any) {
 			oldCm := oldObj.(*apiv1.ConfigMap)
 			newCm := newObj.(*apiv1.ConfigMap)
 			if oldCm.ObjectMeta.ResourceVersion != newCm.ObjectMeta.ResourceVersion {

--- a/pkg/executor/cms/secrethandler.go
+++ b/pkg/executor/cms/secrethandler.go
@@ -50,9 +50,9 @@ func getSecretRelatedFuncs(ctx context.Context, logger *zap.Logger, m *metav1.Ob
 func SecretEventHandlers(ctx context.Context, logger *zap.Logger, fissionClient versioned.Interface,
 	kubernetesClient kubernetes.Interface, types map[fv1.ExecutorType]executortype.ExecutorType) k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) {},
-		DeleteFunc: func(obj interface{}) {},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		AddFunc:    func(obj any) {},
+		DeleteFunc: func(obj any) {},
+		UpdateFunc: func(oldObj any, newObj any) {
 			oldS := oldObj.(*apiv1.Secret)
 			newS := newObj.(*apiv1.Secret)
 			if oldS.ObjectMeta.ResourceVersion != newS.ObjectMeta.ResourceVersion {

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -328,7 +328,7 @@ func (caaf *Container) createFunction(ctx context.Context, fn *fv1.Function) (*f
 		return nil, nil
 	}
 
-	fsvcObj, err := caaf.throttler.RunOnce(string(fn.ObjectMeta.UID), func(ableToCreate bool) (interface{}, error) {
+	fsvcObj, err := caaf.throttler.RunOnce(string(fn.ObjectMeta.UID), func(ableToCreate bool) (any, error) {
 		if ableToCreate {
 			return caaf.fnCreate(ctx, fn)
 		}

--- a/pkg/executor/executortype/container/funchandlers.go
+++ b/pkg/executor/executortype/container/funchandlers.go
@@ -27,7 +27,7 @@ import (
 
 func (caaf *Container) FuncInformerHandler(ctx context.Context) k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			fn := obj.(*fv1.Function)
 			fnExecutorType := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType
 			if fnExecutorType != "" && fnExecutorType != fv1.ExecutorTypeContainer {
@@ -46,7 +46,7 @@ func (caaf *Container) FuncInformerHandler(ctx context.Context) k8sCache.Resourc
 				log.Debug("end function create handler")
 			}()
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			fn := obj.(*fv1.Function)
 			fnExecutorType := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType
 			if fnExecutorType != "" && fnExecutorType != fv1.ExecutorTypeContainer {
@@ -62,7 +62,7 @@ func (caaf *Container) FuncInformerHandler(ctx context.Context) k8sCache.Resourc
 				log.Debug("end function delete handler")
 			}()
 		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		UpdateFunc: func(oldObj any, newObj any) {
 			oldFn := oldObj.(*fv1.Function)
 			newFn := newObj.(*fv1.Function)
 			fnExecutorType := oldFn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType

--- a/pkg/executor/executortype/newdeploy/envhandlers.go
+++ b/pkg/executor/executortype/newdeploy/envhandlers.go
@@ -27,9 +27,9 @@ import (
 
 func (deploy *NewDeploy) EnvEventHandlers() k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) {},
-		DeleteFunc: func(obj interface{}) {},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		AddFunc:    func(obj any) {},
+		DeleteFunc: func(obj any) {},
+		UpdateFunc: func(oldObj any, newObj any) {
 			newEnv := newObj.(*fv1.Environment)
 			oldEnv := oldObj.(*fv1.Environment)
 			ctx := context.Background()

--- a/pkg/executor/executortype/newdeploy/funchandlers.go
+++ b/pkg/executor/executortype/newdeploy/funchandlers.go
@@ -26,7 +26,7 @@ import (
 
 func (deploy *NewDeploy) FunctionEventHandlers() k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			// TODO: A workaround to process items in parallel. We should use workqueue ("k8s.io/client-go/util/workqueue")
 			// and worker pattern to process items instead of moving process to another goroutine.
 			// example: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/job/job_controller.go
@@ -43,7 +43,7 @@ func (deploy *NewDeploy) FunctionEventHandlers() k8sCache.ResourceEventHandlerFu
 				deploy.logger.Debug("end create deployment for function", zap.Any("fn", fn.ObjectMeta), zap.Any("fnspec", fn.Spec))
 			}()
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			fn := obj.(*fv1.Function)
 			go func() {
 				ctx := context.Background()
@@ -55,7 +55,7 @@ func (deploy *NewDeploy) FunctionEventHandlers() k8sCache.ResourceEventHandlerFu
 				}
 			}()
 		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		UpdateFunc: func(oldObj any, newObj any) {
 			oldFn := oldObj.(*fv1.Function)
 			newFn := newObj.(*fv1.Function)
 			go func() {

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -363,7 +363,7 @@ func (deploy *NewDeploy) createFunction(ctx context.Context, fn *fv1.Function) (
 
 	logger := otelUtils.LoggerWithTraceID(ctx, deploy.logger)
 
-	fsvcObj, err := deploy.throttler.RunOnce(string(fn.ObjectMeta.UID), func(ableToCreate bool) (interface{}, error) {
+	fsvcObj, err := deploy.throttler.RunOnce(string(fn.ObjectMeta.UID), func(ableToCreate bool) (any, error) {
 		if ableToCreate {
 			return deploy.fnCreate(ctx, fn)
 		}

--- a/pkg/executor/executortype/poolmgr/funchandlers.go
+++ b/pkg/executor/executortype/poolmgr/funchandlers.go
@@ -43,7 +43,7 @@ func getIstioServiceLabels(fnName string) map[string]string {
 // If istio is enabled, we create a service for the function.
 func FunctionEventHandlers(logger *zap.Logger, kubernetesClient kubernetes.Interface, fissionfnNamespace string, istioEnabled bool) k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			ctx := context.Background()
 			fn := obj.(*fv1.Function)
 
@@ -132,7 +132,7 @@ func FunctionEventHandlers(logger *zap.Logger, kubernetesClient kubernetes.Inter
 			}
 		},
 
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			ctx := context.Background()
 			fn := obj.(*fv1.Function)
 
@@ -160,7 +160,7 @@ func FunctionEventHandlers(logger *zap.Logger, kubernetesClient kubernetes.Inter
 			}
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldFunc := oldObj.(*fv1.Function)
 			newFunc := newObj.(*fv1.Function)
 

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -209,7 +209,7 @@ func (gp *GenericPool) updateCPUUtilizationSvc() {
 				p.Add(container.Usage["cpu"])
 			}
 			if value, ok := gp.podFSVCMap.Load(val.ObjectMeta.Name); ok {
-				if valArray, ok1 := value.([]interface{}); ok1 {
+				if valArray, ok1 := value.([]any); ok1 {
 					function, address := valArray[0], valArray[1]
 					gp.fsCache.SetCPUUtilizaton(function.(string), address.(string), p)
 					gp.logger.Info(fmt.Sprintf("updated function %s, address %s, cpuUsage %+v", function.(string), address.(string), p))
@@ -585,7 +585,7 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 	}
 
 	gp.fsCache.PodToFsvc.Store(pod.GetObjectMeta().GetName(), fsvc)
-	gp.podFSVCMap.Store(pod.ObjectMeta.Name, []interface{}{crd.CacheKey(fsvc.Function), fsvc.Address})
+	gp.podFSVCMap.Store(pod.ObjectMeta.Name, []any{crd.CacheKey(fsvc.Function), fsvc.Address})
 	gp.fsCache.AddFunc(ctx, *fsvc)
 
 	metrics.ColdStarts.WithLabelValues(fn.ObjectMeta.Name, fn.ObjectMeta.Namespace).Inc()

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -681,7 +681,7 @@ func (gpm *GenericPoolManager) WebsocketStartEventChecker(kubeClient kubernetes.
 	stopper := make(chan struct{})
 	defer close(stopper)
 	informer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			mObj := obj.(metav1.Object)
 			gpm.logger.Info("Websocket event detected for pod",
 				zap.String("Pod name", mObj.GetName()))
@@ -722,7 +722,7 @@ func (gpm *GenericPoolManager) NoActiveConnectionEventChecker(kubeClient kuberne
 	stopper := make(chan struct{})
 	defer close(stopper)
 	informer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			mObj := obj.(metav1.Object)
 			gpm.logger.Info("Inactive event detected for pod",
 				zap.String("Pod name", mObj.GetName()))

--- a/pkg/executor/executortype/poolmgr/packagehandlers.go
+++ b/pkg/executor/executortype/poolmgr/packagehandlers.go
@@ -33,7 +33,7 @@ import (
 // for the package which is used by fetcher component.
 func PackageEventHandlers(logger *zap.Logger, kubernetesClient kubernetes.Interface, fissionfnNamespace string) k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			pkg := obj.(*fv1.Package)
 			logger.Debug("list watch for package reported a new package addition",
 				zap.String("package_name", pkg.ObjectMeta.Name),
@@ -64,7 +64,7 @@ func PackageEventHandlers(logger *zap.Logger, kubernetesClient kubernetes.Interf
 				zap.String("package_namespace", pkg.ObjectMeta.Namespace))
 		},
 
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldPkg := oldObj.(*fv1.Package)
 			newPkg := newObj.(*fv1.Package)
 

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -151,7 +151,7 @@ func (p *PoolPodController) processRS(rs *apps.ReplicaSet) {
 	}
 }
 
-func (p *PoolPodController) handleRSAdd(obj interface{}) {
+func (p *PoolPodController) handleRSAdd(obj any) {
 	rs, ok := obj.(*apps.ReplicaSet)
 	if !ok {
 		p.logger.Error("unexpected type when adding rs to pool pod controller", zap.Any("obj", obj))
@@ -160,7 +160,7 @@ func (p *PoolPodController) handleRSAdd(obj interface{}) {
 	p.processRS(rs)
 }
 
-func (p *PoolPodController) handleRSUpdate(oldObj interface{}, newObj interface{}) {
+func (p *PoolPodController) handleRSUpdate(oldObj any, newObj any) {
 	rs, ok := newObj.(*apps.ReplicaSet)
 	if !ok {
 		p.logger.Error("unexpected type when updating rs to pool pod controller", zap.Any("obj", newObj))
@@ -169,7 +169,7 @@ func (p *PoolPodController) handleRSUpdate(oldObj interface{}, newObj interface{
 	p.processRS(rs)
 }
 
-func (p *PoolPodController) handleRSDelete(obj interface{}) {
+func (p *PoolPodController) handleRSDelete(obj any) {
 	rs, ok := obj.(*apps.ReplicaSet)
 	if !ok {
 		tombstone, ok := obj.(k8sCache.DeletedFinalStateUnknown)
@@ -186,7 +186,7 @@ func (p *PoolPodController) handleRSDelete(obj interface{}) {
 	p.processRS(rs)
 }
 
-func (p *PoolPodController) enqueueEnvAdd(obj interface{}) {
+func (p *PoolPodController) enqueueEnvAdd(obj any) {
 	key, err := k8sCache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
 		p.logger.Error("error retrieving key from object in poolPodController", zap.Any("obj", obj))
@@ -196,7 +196,7 @@ func (p *PoolPodController) enqueueEnvAdd(obj interface{}) {
 	p.envCreateUpdateQueue.Add(key)
 }
 
-func (p *PoolPodController) enqueueEnvUpdate(oldObj, newObj interface{}) {
+func (p *PoolPodController) enqueueEnvUpdate(oldObj, newObj any) {
 	key, err := k8sCache.MetaNamespaceKeyFunc(newObj)
 	if err != nil {
 		p.logger.Error("error retrieving key from object in poolPodController", zap.Any("obj", key))
@@ -206,7 +206,7 @@ func (p *PoolPodController) enqueueEnvUpdate(oldObj, newObj interface{}) {
 	p.envCreateUpdateQueue.Add(key)
 }
 
-func (p *PoolPodController) enqueueEnvDelete(obj interface{}) {
+func (p *PoolPodController) enqueueEnvDelete(obj any) {
 	env, ok := obj.(*fv1.Environment)
 	if !ok {
 		p.logger.Error("unexpected type when deleting env to pool pod controller", zap.Any("obj", obj))

--- a/pkg/executor/executortype/poolmgr/readyPodController.go
+++ b/pkg/executor/executortype/poolmgr/readyPodController.go
@@ -12,14 +12,14 @@ import (
 
 func (gp *GenericPool) readyPodEventHandlers() k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			key, err := k8sCache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
 				gp.readyPodQueue.AddAfter(key, 100*time.Millisecond)
 				gp.logger.Debug("add func called", zap.String("key", key))
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			key, err := k8sCache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
 				gp.readyPodQueue.Done(key)

--- a/pkg/executor/util/merge.go
+++ b/pkg/executor/util/merge.go
@@ -240,7 +240,7 @@ func mergeVolumeLists(dst []apiv1.Volume, src []apiv1.Volume) ([]apiv1.Volume, e
 	return dst, err
 }
 
-func checkSliceConflicts(field string, objs interface{}) (err error) {
+func checkSliceConflicts(field string, objs any) (err error) {
 	defer func() {
 		// just in case to recover from unknown error
 		if e := recover(); e != nil {

--- a/pkg/executor/util/merge_test.go
+++ b/pkg/executor/util/merge_test.go
@@ -25,7 +25,7 @@ import (
 
 func Test_checkConflicts(t *testing.T) {
 	type args struct {
-		objs interface{}
+		objs any
 	}
 	tests := []struct {
 		name    string
@@ -44,17 +44,17 @@ func Test_checkConflicts(t *testing.T) {
 		},
 		{
 			name:    "conflict container name",
-			args:    args{[]interface{}{apiv1.Container{Name: "test1"}, apiv1.Container{Name: "test1"}, apiv1.Container{Name: "test3"}}},
+			args:    args{[]any{apiv1.Container{Name: "test1"}, apiv1.Container{Name: "test1"}, apiv1.Container{Name: "test3"}}},
 			wantErr: true,
 		},
 		{
 			name:    "different types",
-			args:    args{[]interface{}{apiv1.VolumeMount{Name: "test1"}, apiv1.EnvFromSource{Prefix: "", ConfigMapRef: nil, SecretRef: nil}}},
+			args:    args{[]any{apiv1.VolumeMount{Name: "test1"}, apiv1.EnvFromSource{Prefix: "", ConfigMapRef: nil, SecretRef: nil}}},
 			wantErr: true,
 		},
 		{
 			name:    "type without target field",
-			args:    args{[]interface{}{apiv1.EnvFromSource{Prefix: "", ConfigMapRef: nil, SecretRef: nil}}},
+			args:    args{[]any{apiv1.EnvFromSource{Prefix: "", ConfigMapRef: nil, SecretRef: nil}}},
 			wantErr: true,
 		},
 	}

--- a/pkg/fetcher/client/client.go
+++ b/pkg/fetcher/client/client.go
@@ -72,7 +72,7 @@ func (c *Client) Upload(ctx context.Context, fr *fetcher.ArchiveUploadRequest) (
 	return &uploadResp, nil
 }
 
-func sendRequest(logger *zap.Logger, ctx context.Context, httpClient *http.Client, req interface{}, url string) ([]byte, error) {
+func sendRequest(logger *zap.Logger, ctx context.Context, httpClient *http.Client, req any, url string) ([]byte, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -90,7 +90,7 @@ func MakeFetcherConfig(sharedMountPath string) (*Config, error) {
 	}, nil
 }
 
-func (cfg *Config) SetupServiceAccount(kubernetesClient kubernetes.Interface, namespace string, context interface{}) error {
+func (cfg *Config) SetupServiceAccount(kubernetesClient kubernetes.Interface, namespace string, context any) error {
 	_, err := utils.SetupSA(kubernetesClient, fv1.FissionFetcherSA, namespace)
 	if err != nil {
 		log.Printf("Error : %v creating %s in ns : %s for: %#v", err, fv1.FissionFetcherSA, namespace, context)

--- a/pkg/fission-cli/cliwrapper/driver/dummy/dummy.go
+++ b/pkg/fission-cli/cliwrapper/driver/dummy/dummy.go
@@ -25,18 +25,18 @@ import (
 var _ fCli.Input = &Cli{}
 
 type Cli struct {
-	c map[string]interface{}
+	c map[string]any
 }
 
 // TestFlagSet returns a flag set for unit test purpose.
 func TestFlagSet() Cli {
-	return Cli{c: make(map[string]interface{})}
+	return Cli{c: make(map[string]any)}
 }
 
 // Set allows to set any kinds of value with given key.
 // The type of set value should be matched with the returned
 // type of GetXXX function.
-func (u Cli) Set(Key string, value interface{}) {
+func (u Cli) Set(Key string, value any) {
 	u.c[Key] = value
 }
 

--- a/pkg/fission-cli/cmd/function/function_test.go
+++ b/pkg/fission-cli/cmd/function/function_test.go
@@ -32,14 +32,14 @@ import (
 func TestGetInvokeStrategy(t *testing.T) {
 	cases := []struct {
 		name                   string
-		testArgs               map[string]interface{}
+		testArgs               map[string]any
 		existingInvokeStrategy *fv1.InvokeStrategy
 		expectedResult         *fv1.InvokeStrategy
 		expectError            bool
 	}{
 		{
 			name:                   "use default executor poolmgr",
-			testArgs:               map[string]interface{}{},
+			testArgs:               map[string]any{},
 			existingInvokeStrategy: nil,
 			expectedResult: &fv1.InvokeStrategy{
 				StrategyType: fv1.StrategyTypeExecution,
@@ -52,7 +52,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name:                   "executor type set to poolmgr",
-			testArgs:               map[string]interface{}{flagkey.FnExecutorType: string(fv1.ExecutorTypePoolmgr)},
+			testArgs:               map[string]any{flagkey.FnExecutorType: string(fv1.ExecutorTypePoolmgr)},
 			existingInvokeStrategy: nil,
 			expectedResult: &fv1.InvokeStrategy{
 				StrategyType: fv1.StrategyTypeExecution,
@@ -65,7 +65,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name:                   "executor type set to newdeploy",
-			testArgs:               map[string]interface{}{flagkey.FnExecutorType: string(fv1.ExecutorTypeNewdeploy)},
+			testArgs:               map[string]any{flagkey.FnExecutorType: string(fv1.ExecutorTypeNewdeploy)},
 			existingInvokeStrategy: nil,
 			expectedResult: &fv1.InvokeStrategy{
 				StrategyType: fv1.StrategyTypeExecution,
@@ -80,7 +80,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name:     "executor type change from poolmgr to newdeploy",
-			testArgs: map[string]interface{}{flagkey.FnExecutorType: string(fv1.ExecutorTypeNewdeploy)},
+			testArgs: map[string]any{flagkey.FnExecutorType: string(fv1.ExecutorTypeNewdeploy)},
 			existingInvokeStrategy: &fv1.InvokeStrategy{
 				StrategyType: fv1.StrategyTypeExecution,
 				ExecutionStrategy: fv1.ExecutionStrategy{
@@ -100,7 +100,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name:     "executor type change from newdeploy to poolmgr",
-			testArgs: map[string]interface{}{flagkey.FnExecutorType: string(fv1.ExecutorTypePoolmgr)},
+			testArgs: map[string]any{flagkey.FnExecutorType: string(fv1.ExecutorTypePoolmgr)},
 			existingInvokeStrategy: &fv1.InvokeStrategy{
 				StrategyType: fv1.StrategyTypeExecution,
 				ExecutionStrategy: fv1.ExecutionStrategy{
@@ -121,7 +121,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "minscale < maxscale",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.ReplicasMinscale: 2,
 				flagkey.ReplicasMaxscale: 3,
@@ -140,7 +140,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "minscale > maxscale",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.ReplicasMinscale: 5,
 				flagkey.ReplicasMaxscale: 3,
@@ -151,7 +151,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "maxscale not specified",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.ReplicasMinscale: 5,
 			},
@@ -169,7 +169,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "minscale not specified",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.ReplicasMaxscale: 3,
 			},
@@ -187,7 +187,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "maxscale set to 0",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.ReplicasMaxscale: 0,
 			},
@@ -197,7 +197,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "update minscale with value larger than existing maxScale",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.ReplicasMinscale: 9,
 			},
@@ -215,7 +215,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "maxscale set to 9 when existing is 5",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.ReplicasMaxscale: 9,
 			},
@@ -241,7 +241,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "change nothing for existing strategy",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType: string(fv1.ExecutorTypeNewdeploy),
 			},
 			existingInvokeStrategy: &fv1.InvokeStrategy{
@@ -266,7 +266,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "set target cpu percentage",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.RuntimeTargetcpu: 50,
 			},
@@ -285,7 +285,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "change target cpu percentage",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:   string(fv1.ExecutorTypeNewdeploy),
 				flagkey.RuntimeTargetcpu: 20,
 			},
@@ -313,7 +313,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "change specializationtimeout",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:          string(fv1.ExecutorTypeNewdeploy),
 				flagkey.FnSpecializationTimeout: 200,
 			},
@@ -338,7 +338,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 		},
 		{
 			name: "specializationtimeout should not be less than 120",
-			testArgs: map[string]interface{}{
+			testArgs: map[string]any{
 				flagkey.FnExecutorType:          string(fv1.ExecutorTypeNewdeploy),
 				flagkey.FnSpecializationTimeout: 90,
 			},

--- a/pkg/fission-cli/cmd/spec/spec.go
+++ b/pkg/fission-cli/cmd/spec/spec.go
@@ -163,7 +163,7 @@ func save(data []byte, specDir string, specFile string) error {
 }
 
 // called from `fission * create --spec`
-func SpecSave(resource interface{}, specFile string) error {
+func SpecSave(resource any, specFile string) error {
 	var specDir = "specs"
 
 	meta, kind, data, err := crdToYaml(resource)
@@ -196,7 +196,7 @@ func SpecSave(resource interface{}, specFile string) error {
 	return nil
 }
 
-func SpecDry(resource interface{}) error {
+func SpecDry(resource any) error {
 	_, _, data, err := crdToYaml(resource)
 	if err != nil {
 		return err
@@ -205,7 +205,7 @@ func SpecDry(resource interface{}) error {
 	return nil
 }
 
-func crdToYaml(resource interface{}) (metav1.ObjectMeta, string, []byte, error) {
+func crdToYaml(resource any) (metav1.ObjectMeta, string, []byte, error) {
 	// make sure we're writing a known type
 	var meta metav1.ObjectMeta
 	var kind string
@@ -658,7 +658,7 @@ func (fr *FissionResources) ParseYaml(b []byte, loc *Location, commitLabelVal st
 // otherwise.  compareMetadata and compareSpec control how the
 // equality check is performed.
 // TODO: deprecated SpecExists
-func (fr *FissionResources) SpecExists(resource interface{}, compareMetadata bool, compareSpec bool) interface{} {
+func (fr *FissionResources) SpecExists(resource any, compareMetadata bool, compareSpec bool) any {
 	switch typedres := resource.(type) {
 	case *types.ArchiveUploadSpec:
 		for _, aus := range fr.ArchiveUploadSpecs {
@@ -692,7 +692,7 @@ func (fr *FissionResources) SpecExists(resource interface{}, compareMetadata boo
 	}
 }
 
-func (fr *FissionResources) ExistsInSpecs(resource interface{}) (bool, error) {
+func (fr *FissionResources) ExistsInSpecs(resource any) (bool, error) {
 	switch typedres := resource.(type) {
 	case types.ArchiveUploadSpec:
 		for _, obj := range fr.ArchiveUploadSpecs {

--- a/pkg/fission-cli/cmd/support/resources/resource.go
+++ b/pkg/fission-cli/cmd/support/resources/resource.go
@@ -42,7 +42,7 @@ func getPodFileName(dumpdir string, pod metav1.ObjectMeta, containerName string)
 	return filepath.Clean(f)
 }
 
-func writeToFile(file string, obj interface{}) {
+func writeToFile(file string, obj any) {
 	bs, err := yaml.Marshal(obj)
 	if err != nil {
 		console.Error(fmt.Sprintf("Error encoding object: %v", err))

--- a/pkg/fission-cli/console/log.go
+++ b/pkg/fission-cli/console/log.go
@@ -29,33 +29,33 @@ var (
 	Verbosity int
 )
 
-func Error(msg interface{}) {
+func Error(msg any) {
 	os.Stderr.WriteString(fmt.Sprintf("%v: %v\n", color.RedString("Error"), trimNewline(msg)))
 }
 
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	os.Stderr.WriteString(fmt.Sprintf("%v: %v\n", color.RedString("Error"), trimNewline(msg)))
 }
 
-func Warn(msg interface{}) {
+func Warn(msg any) {
 	os.Stdout.WriteString(fmt.Sprintf("%v: %v\n", color.YellowString("Warning"), trimNewline(msg)))
 }
 
-func Info(msg interface{}) {
+func Info(msg any) {
 	os.Stdout.WriteString(fmt.Sprintf("%v\n", trimNewline(msg)))
 }
 
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	os.Stdout.WriteString(fmt.Sprintf("%v\n", trimNewline(fmt.Sprintf(format, args...))))
 }
 
-func Verbose(verbosityLevel int, format string, args ...interface{}) {
+func Verbose(verbosityLevel int, format string, args ...any) {
 	if Verbosity >= verbosityLevel {
 		fmt.Printf(format+"\n", args...)
 	}
 }
 
-func trimNewline(m interface{}) string {
+func trimNewline(m any) string {
 	return strings.TrimSuffix(fmt.Sprintf("%v", m), "\n")
 }

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -43,7 +43,7 @@ type (
 		Short        string // one-letter abbreviated flag
 		Aliases      []string
 		Usage        string
-		DefaultValue interface{}
+		DefaultValue any
 
 		// If a flag is marked as deprecated, it will hidden from
 		// the help message automatically. Hence, a flag cannot be

--- a/pkg/fission-cli/logdb/influxdb.go
+++ b/pkg/fission-cli/logdb/influxdb.go
@@ -61,7 +61,7 @@ func (influx InfluxDB) GetLogs(filter LogFilter) ([]LogEntry, error) {
 
 	// please check "Example 4: Bind a parameter in the WHERE clause to specific tag value"
 	// at https://docs.influxdata.com/influxdb/v1.2/tools/api/
-	parameters := make(map[string]interface{})
+	parameters := make(map[string]any)
 	parameters["funcuid"] = filter.FuncUid
 	parameters["time"] = timestamp
 	//the parameters above are only for the where clause and do not work with LIMIT
@@ -186,7 +186,7 @@ func (influx InfluxDB) query(query influxdbClient.Query) (*influxdbClient.Respon
 // Since we switch from fluentd to fluent-bit, there are some field names' changed which will break
 // CLI due to empty value. For backward compatibility, getEntryValue also supports to get value from
 // fallbackIndex if exists, otherwise an empty string returned instead.
-func getEntryValue(list []interface{}, index int, fallbackIndex ...int) string {
+func getEntryValue(list []any, index int, fallbackIndex ...int) string {
 	if index < len(list) && list[index] != nil {
 		return list[index].(string)
 	}

--- a/pkg/generated/clientset/versioned/typed/core/v1/generated_expansion.go
+++ b/pkg/generated/clientset/versioned/typed/core/v1/generated_expansion.go
@@ -18,18 +18,18 @@ limitations under the License.
 
 package v1
 
-type CanaryConfigExpansion interface{}
+type CanaryConfigExpansion any
 
-type EnvironmentExpansion interface{}
+type EnvironmentExpansion any
 
-type FunctionExpansion interface{}
+type FunctionExpansion any
 
-type HTTPTriggerExpansion interface{}
+type HTTPTriggerExpansion any
 
-type KubernetesWatchTriggerExpansion interface{}
+type KubernetesWatchTriggerExpansion any
 
-type MessageQueueTriggerExpansion interface{}
+type MessageQueueTriggerExpansion any
 
-type PackageExpansion interface{}
+type PackageExpansion any
 
-type TimeTriggerExpansion interface{}
+type TimeTriggerExpansion any

--- a/pkg/generated/listers/core/v1/canaryconfig.go
+++ b/pkg/generated/listers/core/v1/canaryconfig.go
@@ -48,7 +48,7 @@ func NewCanaryConfigLister(indexer cache.Indexer) CanaryConfigLister {
 
 // List lists all CanaryConfigs in the indexer.
 func (s *_canaryConfigLister) List(selector labels.Selector) (ret []*v1.CanaryConfig, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1.CanaryConfig))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type _canaryConfigNamespaceLister struct {
 
 // List lists all CanaryConfigs in the indexer for a given namespace.
 func (s _canaryConfigNamespaceLister) List(selector labels.Selector) (ret []*v1.CanaryConfig, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1.CanaryConfig))
 	})
 	return ret, err

--- a/pkg/generated/listers/core/v1/environment.go
+++ b/pkg/generated/listers/core/v1/environment.go
@@ -48,7 +48,7 @@ func NewEnvironmentLister(indexer cache.Indexer) EnvironmentLister {
 
 // List lists all Environments in the indexer.
 func (s *_environmentLister) List(selector labels.Selector) (ret []*v1.Environment, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1.Environment))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type _environmentNamespaceLister struct {
 
 // List lists all Environments in the indexer for a given namespace.
 func (s _environmentNamespaceLister) List(selector labels.Selector) (ret []*v1.Environment, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1.Environment))
 	})
 	return ret, err

--- a/pkg/generated/listers/core/v1/expansion_generated.go
+++ b/pkg/generated/listers/core/v1/expansion_generated.go
@@ -20,64 +20,64 @@ package v1
 
 // CanaryConfigListerExpansion allows custom methods to be added to
 // CanaryConfigLister.
-type CanaryConfigListerExpansion interface{}
+type CanaryConfigListerExpansion any
 
 // CanaryConfigNamespaceListerExpansion allows custom methods to be added to
 // CanaryConfigNamespaceLister.
-type CanaryConfigNamespaceListerExpansion interface{}
+type CanaryConfigNamespaceListerExpansion any
 
 // EnvironmentListerExpansion allows custom methods to be added to
 // EnvironmentLister.
-type EnvironmentListerExpansion interface{}
+type EnvironmentListerExpansion any
 
 // EnvironmentNamespaceListerExpansion allows custom methods to be added to
 // EnvironmentNamespaceLister.
-type EnvironmentNamespaceListerExpansion interface{}
+type EnvironmentNamespaceListerExpansion any
 
 // FunctionListerExpansion allows custom methods to be added to
 // FunctionLister.
-type FunctionListerExpansion interface{}
+type FunctionListerExpansion any
 
 // FunctionNamespaceListerExpansion allows custom methods to be added to
 // FunctionNamespaceLister.
-type FunctionNamespaceListerExpansion interface{}
+type FunctionNamespaceListerExpansion any
 
 // HTTPTriggerListerExpansion allows custom methods to be added to
 // HTTPTriggerLister.
-type HTTPTriggerListerExpansion interface{}
+type HTTPTriggerListerExpansion any
 
 // HTTPTriggerNamespaceListerExpansion allows custom methods to be added to
 // HTTPTriggerNamespaceLister.
-type HTTPTriggerNamespaceListerExpansion interface{}
+type HTTPTriggerNamespaceListerExpansion any
 
 // KubernetesWatchTriggerListerExpansion allows custom methods to be added to
 // KubernetesWatchTriggerLister.
-type KubernetesWatchTriggerListerExpansion interface{}
+type KubernetesWatchTriggerListerExpansion any
 
 // KubernetesWatchTriggerNamespaceListerExpansion allows custom methods to be added to
 // KubernetesWatchTriggerNamespaceLister.
-type KubernetesWatchTriggerNamespaceListerExpansion interface{}
+type KubernetesWatchTriggerNamespaceListerExpansion any
 
 // MessageQueueTriggerListerExpansion allows custom methods to be added to
 // MessageQueueTriggerLister.
-type MessageQueueTriggerListerExpansion interface{}
+type MessageQueueTriggerListerExpansion any
 
 // MessageQueueTriggerNamespaceListerExpansion allows custom methods to be added to
 // MessageQueueTriggerNamespaceLister.
-type MessageQueueTriggerNamespaceListerExpansion interface{}
+type MessageQueueTriggerNamespaceListerExpansion any
 
 // PackageListerExpansion allows custom methods to be added to
 // PackageLister.
-type PackageListerExpansion interface{}
+type PackageListerExpansion any
 
 // PackageNamespaceListerExpansion allows custom methods to be added to
 // PackageNamespaceLister.
-type PackageNamespaceListerExpansion interface{}
+type PackageNamespaceListerExpansion any
 
 // TimeTriggerListerExpansion allows custom methods to be added to
 // TimeTriggerLister.
-type TimeTriggerListerExpansion interface{}
+type TimeTriggerListerExpansion any
 
 // TimeTriggerNamespaceListerExpansion allows custom methods to be added to
 // TimeTriggerNamespaceLister.
-type TimeTriggerNamespaceListerExpansion interface{}
+type TimeTriggerNamespaceListerExpansion any

--- a/pkg/generated/listers/core/v1/function.go
+++ b/pkg/generated/listers/core/v1/function.go
@@ -48,7 +48,7 @@ func NewFunctionLister(indexer cache.Indexer) FunctionLister {
 
 // List lists all Functions in the indexer.
 func (s *_functionLister) List(selector labels.Selector) (ret []*v1.Function, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1.Function))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type _functionNamespaceLister struct {
 
 // List lists all Functions in the indexer for a given namespace.
 func (s _functionNamespaceLister) List(selector labels.Selector) (ret []*v1.Function, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1.Function))
 	})
 	return ret, err

--- a/pkg/generated/listers/core/v1/httptrigger.go
+++ b/pkg/generated/listers/core/v1/httptrigger.go
@@ -48,7 +48,7 @@ func NewHTTPTriggerLister(indexer cache.Indexer) HTTPTriggerLister {
 
 // List lists all HTTPTriggers in the indexer.
 func (s *_hTTPTriggerLister) List(selector labels.Selector) (ret []*v1.HTTPTrigger, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1.HTTPTrigger))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type _hTTPTriggerNamespaceLister struct {
 
 // List lists all HTTPTriggers in the indexer for a given namespace.
 func (s _hTTPTriggerNamespaceLister) List(selector labels.Selector) (ret []*v1.HTTPTrigger, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1.HTTPTrigger))
 	})
 	return ret, err

--- a/pkg/generated/listers/core/v1/kuberneteswatchtrigger.go
+++ b/pkg/generated/listers/core/v1/kuberneteswatchtrigger.go
@@ -48,7 +48,7 @@ func NewKubernetesWatchTriggerLister(indexer cache.Indexer) KubernetesWatchTrigg
 
 // List lists all KubernetesWatchTriggers in the indexer.
 func (s *_kubernetesWatchTriggerLister) List(selector labels.Selector) (ret []*v1.KubernetesWatchTrigger, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1.KubernetesWatchTrigger))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type _kubernetesWatchTriggerNamespaceLister struct {
 
 // List lists all KubernetesWatchTriggers in the indexer for a given namespace.
 func (s _kubernetesWatchTriggerNamespaceLister) List(selector labels.Selector) (ret []*v1.KubernetesWatchTrigger, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1.KubernetesWatchTrigger))
 	})
 	return ret, err

--- a/pkg/generated/listers/core/v1/messagequeuetrigger.go
+++ b/pkg/generated/listers/core/v1/messagequeuetrigger.go
@@ -48,7 +48,7 @@ func NewMessageQueueTriggerLister(indexer cache.Indexer) MessageQueueTriggerList
 
 // List lists all MessageQueueTriggers in the indexer.
 func (s *_messageQueueTriggerLister) List(selector labels.Selector) (ret []*v1.MessageQueueTrigger, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1.MessageQueueTrigger))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type _messageQueueTriggerNamespaceLister struct {
 
 // List lists all MessageQueueTriggers in the indexer for a given namespace.
 func (s _messageQueueTriggerNamespaceLister) List(selector labels.Selector) (ret []*v1.MessageQueueTrigger, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1.MessageQueueTrigger))
 	})
 	return ret, err

--- a/pkg/generated/listers/core/v1/package.go
+++ b/pkg/generated/listers/core/v1/package.go
@@ -48,7 +48,7 @@ func NewPackageLister(indexer cache.Indexer) PackageLister {
 
 // List lists all Packages in the indexer.
 func (s *_packageLister) List(selector labels.Selector) (ret []*v1.Package, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1.Package))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type _packageNamespaceLister struct {
 
 // List lists all Packages in the indexer for a given namespace.
 func (s _packageNamespaceLister) List(selector labels.Selector) (ret []*v1.Package, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1.Package))
 	})
 	return ret, err

--- a/pkg/generated/listers/core/v1/timetrigger.go
+++ b/pkg/generated/listers/core/v1/timetrigger.go
@@ -48,7 +48,7 @@ func NewTimeTriggerLister(indexer cache.Indexer) TimeTriggerLister {
 
 // List lists all TimeTriggers in the indexer.
 func (s *_timeTriggerLister) List(selector labels.Selector) (ret []*v1.TimeTrigger, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1.TimeTrigger))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type _timeTriggerNamespaceLister struct {
 
 // List lists all TimeTriggers in the indexer for a given namespace.
 func (s _timeTriggerNamespaceLister) List(selector labels.Selector) (ret []*v1.TimeTrigger, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1.TimeTrigger))
 	})
 	return ret, err

--- a/pkg/generator/encoder/encoder.go
+++ b/pkg/generator/encoder/encoder.go
@@ -26,8 +26,8 @@ type (
 	EncodeCodec string
 
 	Encoder interface {
-		Marshal(v interface{}) ([]byte, error)
-		Unmarshal(data []byte, v interface{}) error
+		Marshal(v any) ([]byte, error)
+		Unmarshal(data []byte, v any) error
 	}
 
 	JSONEncoder struct{}
@@ -40,11 +40,11 @@ func DefaultJSONEncoder() Encoder {
 	return JSONEncoder{}
 }
 
-func (encoder JSONEncoder) Marshal(v interface{}) ([]byte, error) {
+func (encoder JSONEncoder) Marshal(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
-func (encoder JSONEncoder) Unmarshal(data []byte, v interface{}) error {
+func (encoder JSONEncoder) Unmarshal(data []byte, v any) error {
 	return json.Unmarshal(data, v)
 }
 
@@ -54,10 +54,10 @@ func DefaultYAMLEncoder() Encoder {
 	return YAMLEncoder{}
 }
 
-func (encoder YAMLEncoder) Marshal(v interface{}) ([]byte, error) {
+func (encoder YAMLEncoder) Marshal(v any) ([]byte, error) {
 	return yaml.Marshal(v)
 }
 
-func (encoder YAMLEncoder) Unmarshal(data []byte, v interface{}) error {
+func (encoder YAMLEncoder) Unmarshal(data []byte, v any) error {
 	return yaml.Unmarshal(data, v)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -44,7 +44,7 @@ const (
 
 func podInformerHandlers(zapLogger *zap.Logger) k8sCache.ResourceEventHandler {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			pod := obj.(*corev1.Pod)
 			if !isValidFunctionPodOnNode(pod) || !utils.IsReadyPod(pod) {
 				return
@@ -56,7 +56,7 @@ func podInformerHandlers(zapLogger *zap.Logger) k8sCache.ResourceEventHandler {
 					zap.String("function", funcName), zap.Error(err))
 			}
 		},
-		UpdateFunc: func(_, obj interface{}) {
+		UpdateFunc: func(_, obj any) {
 			pod := obj.(*corev1.Pod)
 			if !isValidFunctionPodOnNode(pod) || !utils.IsReadyPod(pod) {
 				return
@@ -68,7 +68,7 @@ func podInformerHandlers(zapLogger *zap.Logger) k8sCache.ResourceEventHandler {
 					zap.String("function", funcName), zap.Error(err))
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			// Do nothing here, let symlink reaper to recycle orphan symlink file
 		},
 	}

--- a/pkg/mqtrigger/messageQueue/messageQueue.go
+++ b/pkg/mqtrigger/messageQueue/messageQueue.go
@@ -21,7 +21,7 @@ import (
 )
 
 type (
-	Subscription interface{}
+	Subscription any
 
 	Config struct {
 		MQType  string

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -183,12 +183,12 @@ func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueue
 
 func (mqt *MessageQueueTriggerManager) mqtInformerHandlers() k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			trigger := obj.(*fv1.MessageQueueTrigger)
 			mqt.logger.Debug("Added mqt", zap.Any("trigger: ", trigger.ObjectMeta))
 			mqt.RegisterTrigger(trigger)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			trigger := obj.(*fv1.MessageQueueTrigger)
 			mqt.logger.Debug("Delete mqt", zap.Any("trigger: ", trigger.ObjectMeta))
 			triggerSubscription := mqt.getTriggerSubscription(trigger)
@@ -208,7 +208,7 @@ func (mqt *MessageQueueTriggerManager) mqtInformerHandlers() k8sCache.ResourceEv
 			}
 			mqt.logger.Info("message queue trigger deleted", zap.String("trigger_name", trigger.ObjectMeta.Name))
 		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		UpdateFunc: func(oldObj any, newObj any) {
 			trigger := newObj.(*fv1.MessageQueueTrigger)
 			mqt.logger.Debug("Updated mqt", zap.Any("trigger: ", trigger.ObjectMeta))
 			mqt.RegisterTrigger(trigger)

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -68,7 +68,7 @@ func getAuthTriggerClient(namespace string) (dynamic.ResourceInterface, error) {
 
 func mqTriggerEventHandlers(logger *zap.Logger, kubeClient kubernetes.Interface, routerURL string) k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			go func() {
 				mqt := obj.(*fv1.MessageQueueTrigger)
 				if mqt.Spec.MqtKind == "fission" {
@@ -110,7 +110,7 @@ func mqTriggerEventHandlers(logger *zap.Logger, kubeClient kubernetes.Interface,
 				}
 			}()
 		},
-		UpdateFunc: func(obj interface{}, newObj interface{}) {
+		UpdateFunc: func(obj any, newObj any) {
 			go func() {
 				mqt := obj.(*fv1.MessageQueueTrigger)
 				newMqt := newObj.(*fv1.MessageQueueTrigger)
@@ -305,23 +305,23 @@ func getAuthTriggerSpec(mqt *fv1.MessageQueueTrigger, authenticationRef string, 
 	if err != nil {
 		return nil, err
 	}
-	var secretTargetRefFields []interface{}
+	var secretTargetRefFields []any
 	for secretField := range secret.Data {
-		secretTargetRefFields = append(secretTargetRefFields, map[string]interface{}{
+		secretTargetRefFields = append(secretTargetRefFields, map[string]any{
 			"name":      mqt.Spec.Secret,
 			"parameter": secretField,
 			"key":       secretField,
 		})
 	}
 	authTriggerObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "TriggerAuthentication",
 			"apiVersion": apiVersion,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      authenticationRef,
 				"namespace": mqt.ObjectMeta.Namespace,
-				"ownerReferences": []interface{}{
-					map[string]interface{}{
+				"ownerReferences": []any{
+					map[string]any{
 						"kind":               "MessageQueueTrigger",
 						"apiVersion":         "fission.io/v1",
 						"name":               mqt.ObjectMeta.Name,
@@ -330,7 +330,7 @@ func getAuthTriggerSpec(mqt *fv1.MessageQueueTrigger, authenticationRef string, 
 					},
 				},
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"secretTargetRef": secretTargetRefFields,
 			},
 		},
@@ -484,14 +484,14 @@ func deleteDeployment(name string, namespace string, kubeClient kubernetes.Inter
 
 func getScaledObject(mqt *fv1.MessageQueueTrigger, authenticationRef string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "ScaledObject",
 			"apiVersion": apiVersion,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      mqt.ObjectMeta.Name,
 				"namespace": mqt.ObjectMeta.Namespace,
-				"ownerReferences": []interface{}{
-					map[string]interface{}{
+				"ownerReferences": []any{
+					map[string]any{
 						"kind":               "MessageQueueTrigger",
 						"apiVersion":         "fission.io/v1",
 						"name":               mqt.ObjectMeta.Name,
@@ -500,19 +500,19 @@ func getScaledObject(mqt *fv1.MessageQueueTrigger, authenticationRef string) *un
 					},
 				},
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"cooldownPeriod":  &mqt.Spec.CooldownPeriod,
 				"maxReplicaCount": &mqt.Spec.MaxReplicaCount,
 				"minReplicaCount": &mqt.Spec.MinReplicaCount,
 				"pollingInterval": &mqt.Spec.PollingInterval,
-				"scaleTargetRef": map[string]interface{}{
+				"scaleTargetRef": map[string]any{
 					"name": mqt.ObjectMeta.Name,
 				},
-				"triggers": []interface{}{
-					map[string]interface{}{
+				"triggers": []any{
+					map[string]any{
 						"type":     mqt.Spec.MessageQueueType,
 						"metadata": mqt.Spec.Metadata,
-						"authenticationRef": map[string]interface{}{
+						"authenticationRef": map[string]any{
 							"name": authenticationRef,
 						},
 					},

--- a/pkg/mqtrigger/scalermanager_test.go
+++ b/pkg/mqtrigger/scalermanager_test.go
@@ -436,14 +436,14 @@ func Test_getAuthTriggerSpec(t *testing.T) {
 	authenticationRef := fmt.Sprintf("%s-auth-trigger", mqt1.ObjectMeta.Name)
 
 	expectedAuthTriggerObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "TriggerAuthentication",
 			"apiVersion": apiVersion,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      authenticationRef,
 				"namespace": mqt1.ObjectMeta.Namespace,
-				"ownerReferences": []interface{}{
-					map[string]interface{}{
+				"ownerReferences": []any{
+					map[string]any{
 						"kind":               "MessageQueueTrigger",
 						"apiVersion":         "fission.io/v1",
 						"name":               mqt1.ObjectMeta.Name,
@@ -452,34 +452,34 @@ func Test_getAuthTriggerSpec(t *testing.T) {
 					},
 				},
 			},
-			"spec": map[string]interface{}{
-				"secretTargetRef": []interface{}{
-					map[string]interface{}{
+			"spec": map[string]any{
+				"secretTargetRef": []any{
+					map[string]any{
 						"name":      mqt1.Spec.Secret,
 						"parameter": "authMode",
 						"key":       "authMode",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":      mqt1.Spec.Secret,
 						"parameter": "username",
 						"key":       "username",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":      mqt1.Spec.Secret,
 						"parameter": "password",
 						"key":       "password",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":      mqt1.Spec.Secret,
 						"parameter": "ca",
 						"key":       "ca",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":      mqt1.Spec.Secret,
 						"parameter": "cert",
 						"key":       "cert",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":      mqt1.Spec.Secret,
 						"parameter": "key",
 						"key":       "key",
@@ -546,16 +546,16 @@ func Test_getAuthTriggerSpec(t *testing.T) {
 				return
 			}
 
-			gotSpec := got.Object["spec"].(map[string]interface{})["secretTargetRef"].([]interface{})
+			gotSpec := got.Object["spec"].(map[string]any)["secretTargetRef"].([]any)
 
 			sort.Slice(gotSpec, func(i, j int) bool {
-				return gotSpec[i].(map[string]interface{})["parameter"].(string) < gotSpec[j].(map[string]interface{})["parameter"].(string)
+				return gotSpec[i].(map[string]any)["parameter"].(string) < gotSpec[j].(map[string]any)["parameter"].(string)
 			})
 
-			wantSpec := tt.want.Object["spec"].(map[string]interface{})["secretTargetRef"].([]interface{})
+			wantSpec := tt.want.Object["spec"].(map[string]any)["secretTargetRef"].([]any)
 
 			sort.Slice(wantSpec, func(i, j int) bool {
-				return wantSpec[i].(map[string]interface{})["parameter"].(string) < wantSpec[j].(map[string]interface{})["parameter"].(string)
+				return wantSpec[i].(map[string]any)["parameter"].(string) < wantSpec[j].(map[string]any)["parameter"].(string)
 			})
 
 			if !reflect.DeepEqual(got.Object["kind"], tt.want.Object["kind"]) &&

--- a/pkg/router/auth.go
+++ b/pkg/router/auth.go
@@ -31,7 +31,7 @@ func checkAuthToken(r *http.Request) error {
 	}
 
 	jwtToken := authHeader[1]
-	token, err := jwt.Parse(jwtToken, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(jwtToken, func(token *jwt.Token) (any, error) {
 		return []byte(os.Getenv("JWT_SIGNING_KEY")), nil
 	})
 

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -690,7 +690,7 @@ func (fh functionHandler) getServiceEntry(ctx context.Context) (svcURL *url.URL,
 	fnMeta := &fh.function.ObjectMeta
 	recordObj, err := fh.svcAddrUpdateThrottler.RunOnce(
 		crd.CacheKey(fnMeta),
-		func(firstToTheLock bool) (interface{}, error) {
+		func(firstToTheLock bool) (any, error) {
 			if !firstToTheLock {
 				svcURL, err := fh.getServiceEntryFromCache()
 				if err != nil {

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -281,17 +281,17 @@ func (ts *HTTPTriggerSet) updateTriggerStatusFailed(ht *fv1.HTTPTrigger, err err
 
 func (ts *HTTPTriggerSet) addTriggerHandlers() {
 	ts.triggerInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			trigger := obj.(*fv1.HTTPTrigger)
 			go createIngress(ts.logger, trigger, ts.kubeClient)
 			ts.syncTriggers()
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			ts.syncTriggers()
 			trigger := obj.(*fv1.HTTPTrigger)
 			go deleteIngress(ts.logger, trigger, ts.kubeClient)
 		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		UpdateFunc: func(oldObj any, newObj any) {
 			oldTrigger := oldObj.(*fv1.HTTPTrigger)
 			newTrigger := newObj.(*fv1.HTTPTrigger)
 
@@ -307,13 +307,13 @@ func (ts *HTTPTriggerSet) addTriggerHandlers() {
 
 func (ts *HTTPTriggerSet) addFunctionHandlers() {
 	ts.funcInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			ts.syncTriggers()
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			ts.syncTriggers()
 		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		UpdateFunc: func(oldObj any, newObj any) {
 			oldFn := oldObj.(*fv1.Function)
 			fn := newObj.(*fv1.Function)
 

--- a/pkg/storagesvc/stowClient.go
+++ b/pkg/storagesvc/stowClient.go
@@ -195,10 +195,10 @@ func (client *StowClient) getFileSize(itemID string) (int64, error) {
 }
 
 // filter defines an interface to filter out items from a set of items
-type filter func(stow.Item, interface{}) bool
+type filter func(stow.Item, any) bool
 
 // This method returns all items in a container, filtering out items based on the filter function passed to it
-func (client *StowClient) getItemIDsWithFilter(filterFunc filter, filterFuncParam interface{}) ([]string, error) {
+func (client *StowClient) getItemIDsWithFilter(filterFunc filter, filterFuncParam any) ([]string, error) {
 	cursor := stow.CursorStart
 	var items []stow.Item
 	var err error
@@ -229,7 +229,7 @@ func (client *StowClient) getItemIDsWithFilter(filterFunc filter, filterFuncPara
 
 // filterItemCreatedAMinuteAgo is one type of filter function that filters out items created less than a minute ago.
 // More filter functions can be written if needed, as long as they are of type filter
-func (client StowClient) filterItemCreatedAMinuteAgo(item stow.Item, currentTime interface{}) bool {
+func (client StowClient) filterItemCreatedAMinuteAgo(item stow.Item, currentTime any) bool {
 	itemLastModTime, _ := item.LastMod()
 	if currentTime.(time.Time).Sub(itemLastModTime) < 1*time.Minute {
 
@@ -241,7 +241,7 @@ func (client StowClient) filterItemCreatedAMinuteAgo(item stow.Item, currentTime
 	return false
 }
 
-func (client StowClient) filterAllItems(item stow.Item, _ interface{}) bool {
+func (client StowClient) filterAllItems(item stow.Item, _ any) bool {
 	itemLastModTime, _ := item.LastMod()
 	client.logger.Debug("item info",
 		zap.String("item", item.ID()),

--- a/pkg/throttler/throttler.go
+++ b/pkg/throttler/throttler.go
@@ -184,7 +184,7 @@ func (tr *Throttler) service() {
 //   }
 
 func (tr *Throttler) RunOnce(resourceKey string,
-	callbackFunc func(bool) (interface{}, error)) (interface{}, error) {
+	callbackFunc func(bool) (any, error)) (any, error) {
 
 	ch := make(chan *response)
 	tr.requestChan <- &request{

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -114,7 +114,7 @@ func TestTracker(t *testing.T) {
 	})
 }
 
-func MockHTTPServer(status int, encodeValue interface{}) *httptest.Server {
+func MockHTTPServer(status int, encodeValue any) *httptest.Server {
 	f := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "application/json")

--- a/test/benchmark/picasso.go
+++ b/test/benchmark/picasso.go
@@ -138,7 +138,7 @@ func generateChart(title string, file string, format chart.RendererProvider, ser
 			Range: &chart.ContinuousRange{
 				Min: 0,
 			},
-			ValueFormatter: func(v interface{}) string {
+			ValueFormatter: func(v any) string {
 				return fmt.Sprintf("%.2f s", v.(float64))
 			},
 		},
@@ -149,7 +149,7 @@ func generateChart(title string, file string, format chart.RendererProvider, ser
 			Range: &chart.ContinuousRange{
 				Min: 0,
 			},
-			ValueFormatter: func(v interface{}) string {
+			ValueFormatter: func(v any) string {
 				return fmt.Sprintf("%d ms", int(v.(float64)))
 			},
 		},


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)